### PR TITLE
Define difference in build/publish

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,9 +1,47 @@
+---
 kind: pipeline
 type: docker
-name: build
+name: build-pr
 
 clone:
   disable: true
+
+steps:
+  - name: clone
+    image: plugins/git
+    settings:
+      recursive: true
+      tags: true
+  - name: build
+    image: plugins/docker
+    depends_on: [ clone ]
+    trigger:
+      event:
+        - pull_request
+    settings:
+      repo: hashbang/book
+      username: hashbangbot
+      password:
+        from_secret: dockerhub_ro_passphrase
+      purge: true
+      dry_run: true
+
+trigger:
+  event:
+    - pull_request
+---
+kind: pipeline
+type: docker
+name: build-master
+
+clone:
+  disable: true
+
+trigger:
+  branch:
+    - master
+  event:
+    - push
 
 steps:
   - name: clone

--- a/.drone.yml
+++ b/.drone.yml
@@ -13,18 +13,14 @@ steps:
       recursive: true
       tags: true
   - name: build
-    image: plugins/docker
+    # https://github.com/drGrove/drone-kaniko/tree/v0.7.0
+    image: drgrove/drone-kaniko@sha256:e3045421c3683e6baf5628b22ea0ee1cd7ae217f4de0e1bc53a0a1a20335b108
     depends_on: [ clone ]
-    trigger:
-      event:
-        - pull_request
     settings:
-      repo: hashbang/book
-      username: hashbangbot
+      reproducible: true
+      username: hashbangdrone
       password:
         from_secret: dockerhub_ro_passphrase
-      purge: true
-      dry_run: true
 
 trigger:
   event:
@@ -50,11 +46,17 @@ steps:
       recursive: true
       tags: true
   - name: build
-    image: plugins/docker
+    # https://github.com/drGrove/drone-kaniko/tree/v0.7.0
+    image: drgrove/drone-kaniko@sha256:e3045421c3683e6baf5628b22ea0ee1cd7ae217f4de0e1bc53a0a1a20335b108
     depends_on: [ clone ]
     settings:
       repo: hashbang/book
+      reproducible: true
       username: hashbangbot
       password:
         from_secret: dockerhub_password
-      purge: true
+---
+kind: signature
+hmac: 720d2cca26760af37303f42d5d96f99fc70f56b905dad020b5c1e49a30dbc0ee
+
+...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
-ARG GOLANG_VERSION=buster
-ARG GOLANG_DIGEST=sha256:544b2d0378d9de9a8ade9cebd9a333e60cc8343f9d3dd01ccccfc4c1395ce132
-ARG DEBIAN_VERSION=buster-slim
-ARG DEBIAN_DIGEST=sha256:0c679627b3a61b2e3ee902ec224b0505839bc2ad76d99530e5f0566e47ac8400
+# buster
+ARG GOLANG_DIGEST=sha256:8f7c5b9000f0531bb28860dc1232ca0defa346361e2003dbf324982407cfe927
 
-FROM golang:${GOLANG_VERSION}@${GOLANG_DIGEST} as builder
-ARG HUGO_VERSION=0.62.1
+# 1.21.0
+ARG NGINX_DIGEST=sha256:61191087790c31e43eb37caa10de1135b002f10c09fdda7fa8a5989db74033aa
+
+FROM golang@${GOLANG_DIGEST} as builder
+ARG HUGO_VERSION=0.83.1
 RUN \
   wget https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_Linux-64bit.deb \
   && dpkg -i hugo_extended_${HUGO_VERSION}_Linux-64bit.deb
@@ -14,8 +15,7 @@ RUN hugo --theme book -d /src/site/public -s .
 CMD ["/usr/local/bin/hugo", "server", "--bind", "0.0.0.0"]
 
 
-FROM debian:${DEBIAN_VERSION}@${DEBIAN_DIGEST} as server
-RUN apt-get update && apt-get install -y nginx
+FROM nginx@${NGINX_DIGEST} as server
 COPY --from=builder /src/site/public/ /usr/share/nginx/html/
 COPY nginx.conf /etc/nginx/nginx.conf
 RUN \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=latest
+VERSION := $(shell git describe --tags --always)
 
 .PHONY:
 submodule:
@@ -17,4 +17,7 @@ dev-server:
 
 .PHONY: image
 image:
-	docker build $(BUILD_ARGS) -t hashbang/book:$(VERSION) .
+	docker build \
+		$(BUILD_ARGS) \
+		-t hashbang/book:$(VERSION) \
+		.


### PR DESCRIPTION
PRs should check that the image builds while pushes to master should
acutally generate an image. This also is needed because dockerhub has
instilled rate limits meaning that we must have a bot user with
credentials. To prevent leaks this bot user has no actual access to
hashbang builds and can only pull public images.